### PR TITLE
Added no environments view on overview page

### DIFF
--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -386,62 +386,64 @@ export const SecretOverviewPage = () => {
                   leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
                 />
               </div>
-              <div>
-                <ProjectPermissionCan
-                  I={ProjectPermissionActions.Create}
-                  a={subject(ProjectPermissionSub.Secrets, { secretPath })}
-                >
-                  {(isAllowed) => (
-                    <Button
-                      variant="outline_bg"
-                      leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                      onClick={() => handlePopUpOpen("addSecretsInAllEnvs")}
-                      className="h-10 rounded-r-none"
-                      isDisabled={!isAllowed}
-                    >
-                      Add Secret
-                    </Button>
-                  )}
-                </ProjectPermissionCan>
-                <DropdownMenu
-                  open={popUp.misc.isOpen}
-                  onOpenChange={(isOpen) => handlePopUpToggle("misc", isOpen)}
-                >
-                  <DropdownMenuTrigger asChild>
-                    <IconButton
-                      ariaLabel="add-folder-or-import"
-                      variant="outline_bg"
-                      className="rounded-l-none bg-mineshaft-600 p-3"
-                    >
-                      <FontAwesomeIcon icon={faAngleDown} />
-                    </IconButton>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <div className="flex flex-col space-y-1 p-1.5">
-                      <ProjectPermissionCan
-                        I={ProjectPermissionActions.Create}
-                        a={subject(ProjectPermissionSub.Secrets, { secretPath })}
+              {userAvailableEnvs.length > 0 && (
+                <div>
+                  <ProjectPermissionCan
+                    I={ProjectPermissionActions.Create}
+                    a={subject(ProjectPermissionSub.Secrets, { secretPath })}
+                  >
+                    {(isAllowed) => (
+                      <Button
+                        variant="outline_bg"
+                        leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                        onClick={() => handlePopUpOpen("addSecretsInAllEnvs")}
+                        className="h-10 rounded-r-none"
+                        isDisabled={!isAllowed}
                       >
-                        {(isAllowed) => (
-                          <Button
-                            leftIcon={<FontAwesomeIcon icon={faFolderPlus} />}
-                            onClick={() => {
-                              handlePopUpOpen("addFolder");
-                              handlePopUpClose("misc");
-                            }}
-                            isDisabled={!isAllowed}
-                            variant="outline_bg"
-                            className="h-10"
-                            isFullWidth
-                          >
-                            Add Folder
-                          </Button>
-                        )}
-                      </ProjectPermissionCan>
-                    </div>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+                        Add Secret
+                      </Button>
+                    )}
+                  </ProjectPermissionCan>
+                  <DropdownMenu
+                    open={popUp.misc.isOpen}
+                    onOpenChange={(isOpen) => handlePopUpToggle("misc", isOpen)}
+                  >
+                    <DropdownMenuTrigger asChild>
+                      <IconButton
+                        ariaLabel="add-folder-or-import"
+                        variant="outline_bg"
+                        className="rounded-l-none bg-mineshaft-600 p-3"
+                      >
+                        <FontAwesomeIcon icon={faAngleDown} />
+                      </IconButton>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <div className="flex flex-col space-y-1 p-1.5">
+                        <ProjectPermissionCan
+                          I={ProjectPermissionActions.Create}
+                          a={subject(ProjectPermissionSub.Secrets, { secretPath })}
+                        >
+                          {(isAllowed) => (
+                            <Button
+                              leftIcon={<FontAwesomeIcon icon={faFolderPlus} />}
+                              onClick={() => {
+                                handlePopUpOpen("addFolder");
+                                handlePopUpClose("misc");
+                              }}
+                              isDisabled={!isAllowed}
+                              variant="outline_bg"
+                              className="h-10"
+                              isFullWidth
+                            >
+                              Add Folder
+                            </Button>
+                          )}
+                        </ProjectPermissionCan>
+                      </div>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -504,14 +506,18 @@ export const SecretOverviewPage = () => {
                     className="bg-mineshaft-700"
                   />
                 )}
-                {isTableEmpty && !isTableLoading && (
+                {userAvailableEnvs.length === 0 && (
                   <Tr>
                     <Td colSpan={userAvailableEnvs.length + 1}>
-                      <EmptyState title="Let's add some secrets" icon={faFolderBlank} iconSize="3x">
+                      <EmptyState
+                        title="You have no environments, start by adding some"
+                        iconSize="3x"
+                      >
                         <Link
                           href={{
-                            pathname: "/project/[id]/secrets/[env]",
-                            query: { id: workspaceId, env: userAvailableEnvs?.[0]?.slug }
+                            pathname: "/project/[id]/settings",
+                            query: { id: workspaceId },
+                            hash: "environments"
                           }}
                         >
                           <Button
@@ -520,9 +526,26 @@ export const SecretOverviewPage = () => {
                             colorSchema="primary"
                             size="md"
                           >
-                            Go to {userAvailableEnvs?.[0]?.name}
+                            Add environments
                           </Button>
                         </Link>
+                      </EmptyState>
+                    </Td>
+                  </Tr>
+                )}
+                {isTableEmpty && !isTableLoading && (
+                  <Tr>
+                    <Td colSpan={userAvailableEnvs.length + 1}>
+                      <EmptyState title="Let's add some secrets" icon={faFolderBlank} iconSize="3x">
+                        <Button
+                          className="mt-4"
+                          variant="outline_bg"
+                          colorSchema="primary"
+                          size="md"
+                          onClick={() => handlePopUpOpen("addSecretsInAllEnvs")}
+                        >
+                          Add Secrets
+                        </Button>
                       </EmptyState>
                     </Td>
                   </Tr>

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -171,7 +171,7 @@ export const CreateSecretForm = ({
             )}
           />
           <FormLabel label="Environments" className="mb-2" />
-          <div className="thin-scrollbar grid max-h-64 grid-cols-3 gap-4 overflow-auto ">
+          <div className="thin-scrollbar grid max-h-64 grid-cols-3 gap-4 overflow-auto py-2">
             {environments.map((env) => {
               return (
                 <Controller
@@ -183,13 +183,20 @@ export const CreateSecretForm = ({
                       isChecked={field.value}
                       onCheckedChange={field.onChange}
                       id={`secret-input-${env.slug}`}
+                      className="!justify-start"
                     >
-                      {env.name}
-                      {getSecretByKey(env.slug, newSecretKey) && (
-                        <Tooltip content="Secret exists. Will be overwritten">
-                          <FontAwesomeIcon icon={faWarning} className="ml-1 text-yellow-400" />
-                        </Tooltip>
-                      )}
+                      <span className="flex w-full flex-row items-center justify-start whitespace-pre-wrap">
+                        <span title={env.name} className="truncate">
+                          {env.name}
+                        </span>
+                        <span>
+                          {getSecretByKey(env.slug, newSecretKey) && (
+                            <Tooltip content="Secret exists. Will be overwritten">
+                              <FontAwesomeIcon icon={faWarning} className="ml-1 text-yellow-400" />
+                            </Tooltip>
+                          )}
+                        </span>
+                      </span>
                     </Checkbox>
                   )}
                 />

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/EnvironmentSection/EnvironmentSection.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/EnvironmentSection/EnvironmentSection.tsx
@@ -63,7 +63,10 @@ export const EnvironmentSection = () => {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+    <div
+      id="environments"
+      className="mb-6 scroll-m-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4"
+    >
       <div className="mb-8 flex justify-between">
         <p className="text-xl font-semibold text-mineshaft-100">Environments</p>
         <div>


### PR DESCRIPTION
Hidden add secret button if no environments present Fixed overflow in add secrets popup

# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->